### PR TITLE
Add dark mode logo support and remove white backdrop

### DIFF
--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -3,21 +3,53 @@ import { cn } from "@/lib/utils";
 interface BrandLogoProps {
   className?: string;
   size?: "sm" | "md" | "lg";
+  lightSrc?: string;
+  darkSrc?: string;
+  useDarkVariantInDarkMode?: boolean;
 }
 
-const LOGO_URL =
+const DEFAULT_LIGHT_LOGO =
   "https://cdn.builder.io/api/v1/image/assets%2F47503cb593a04fafbd97599f9b784a6d%2F8c46d28774654d78bef06b344858d079?format=webp&width=800";
 
-export function BrandLogo({ className, size = "md" }: BrandLogoProps) {
+export function BrandLogo({
+  className,
+  size = "md",
+  lightSrc = DEFAULT_LIGHT_LOGO,
+  darkSrc,
+  useDarkVariantInDarkMode = false,
+}: BrandLogoProps) {
   const sizeClasses = {
     sm: "h-10",
     md: "h-20",
     lg: "h-28",
   }[size];
 
+  if (useDarkVariantInDarkMode && darkSrc) {
+    return (
+      <>
+        <img
+          src={lightSrc}
+          alt="KenneDyne spot logo"
+          className={cn("block dark:hidden w-auto object-contain", sizeClasses, className)}
+          aria-label="KenneDyne spot"
+          loading="lazy"
+          decoding="async"
+        />
+        <img
+          src={darkSrc}
+          alt="KenneDyne spot logo"
+          className={cn("hidden dark:block w-auto object-contain", sizeClasses, className)}
+          aria-label="KenneDyne spot"
+          loading="lazy"
+          decoding="async"
+        />
+      </>
+    );
+  }
+
   return (
     <img
-      src={LOGO_URL}
+      src={lightSrc}
       alt="KenneDyne spot logo"
       className={cn("block w-auto object-contain", sizeClasses, className)}
       aria-label="KenneDyne spot"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -31,10 +31,15 @@ export function Navigation() {
   const nestedIcons = [Star, BookOpen, Briefcase, BarChart2, Sparkles, MapPin, Calendar, FileText];
 
   return (
-    <nav aria-label="Main" className="sticky top-0 z-50 w-full border-b border-border/30 bg-background/90 dark:bg-white/40 backdrop-blur-md supports-[backdrop-filter]:bg-background/60">
+    <nav aria-label="Main" className="sticky top-0 z-50 w-full border-b border-border/30 bg-background/90 dark:bg-background/90 backdrop-blur-md supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 lg:h-28 items-center justify-between px-4">
         <Link to="/" className="flex items-center space-x-3" aria-label="Home">
-          <BrandLogo size="md" className="h-12 lg:h-28" />
+          <BrandLogo
+            size="md"
+            className="h-12 lg:h-28"
+            useDarkVariantInDarkMode
+            darkSrc="https://cdn.builder.io/api/v1/image/assets%2Fd70b5c32436e40df8a1857905f23cae8%2F97e09281a0ad46bda113d0fd0850162f?format=webp&width=800"
+          />
         </Link>
 
         {/* Desktop Navigation */}
@@ -151,7 +156,12 @@ export function Navigation() {
           <SheetContent side="right" id="mobile-menu" className="w-80 glass-card border-l border-border/50">
             <div className="flex flex-col space-y-6 mt-6 px-4">
               <div className="flex items-center justify-between">
-                <BrandLogo size="md" className="h-16" />
+                <BrandLogo
+                  size="md"
+                  className="h-16"
+                  useDarkVariantInDarkMode
+                  darkSrc="https://cdn.builder.io/api/v1/image/assets%2Fd70b5c32436e40df8a1857905f23cae8%2F97e09281a0ad46bda113d0fd0850162f?format=webp&width=800"
+                />
                 <div className="flex items-center space-x-2">
                   <Button variant="outline" size="sm" onClick={toggleLanguage} aria-label="Switch language">
                     {language.toUpperCase()}


### PR DESCRIPTION
## Purpose

The user requested to implement dark mode-specific branding by using a different logo for dark mode only and removing the white backdrop that was previously applied in dark mode. They also wanted to ensure the light mode logo is used for both header and footer in light mode.

## Code changes

- **Enhanced BrandLogo component**: Added new props `lightSrc`, `darkSrc`, and `useDarkVariantInDarkMode` to support conditional logo rendering based on theme
- **Conditional logo rendering**: Implemented logic to show different logos for light and dark modes using Tailwind's `dark:` classes
- **Navigation styling fix**: Removed white backdrop in dark mode by changing `dark:bg-white/40` to `dark:bg-background/90`
- **Logo integration**: Updated Navigation component to use the new dark mode logo functionality with the specified dark mode logo URL
- **Mobile menu support**: Applied the same dark mode logo logic to the mobile navigation menuTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3cc3f184d8af4eba80e49b06be61a24d/flare-realm)

👀 [Preview Link](https://3cc3f184d8af4eba80e49b06be61a24d-flare-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3cc3f184d8af4eba80e49b06be61a24d</projectId>-->
<!--<branchName>flare-realm</branchName>-->