### PR TITLE
Fix language toggle for DriveStrategySection and Navigation

### DIFF
--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -94,7 +94,7 @@ export function DriveStrategySection() {
               </Button>
               <Button variant="outline" size="lg" className="hover:scale-105 transition-transform duration-300" asChild>
                 <a {...getExternalLinkProps(LINKS.telegram.community)} aria-label="Join our Telegram community">
-                  Join on Telegram
+                  {t('join_on_telegram')}
                   <ArrowRight className="h-4 w-4" />
                 </a>
               </Button>

--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -4,6 +4,8 @@ import { ArrowRight } from "lucide-react";
 import { driveStepsSimple } from "@/content/drive";
 import { Link } from "react-router-dom";
 import { LINKS, getExternalLinkProps } from "@/constants/links";
+import { useI18n } from '@/i18n';
+import React from 'react';
 
 export function DriveStrategySection() {
   return (

--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -27,13 +27,13 @@ export function DriveStrategySection() {
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-12 lg:mb-16">
             <h2 className="fluid-h2 text-foreground mb-3">
-              The <span className="text-primary">D.R.I.V.E</span> Strategy Framework
+              {t('drive_framework_title')}
             </h2>
             <p className="text-sm text-muted-foreground/80 mb-4 font-medium tracking-wide">
-              Direction. Range. Interest Point. Value of Risk. Entry.
+              {t('drive_acronym_full')}
             </p>
             <p className="fluid-body text-muted-foreground max-w-3xl mx-auto">
-              A systematic 5-step methodology that transforms retail traders into institutional professionals.
+              {t('drive_framework_description')}
             </p>
           </div>
 

--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -88,7 +88,7 @@ export function DriveStrategySection() {
             <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
               <Button variant="default" size="lg" className="hover:scale-105 transition-transform duration-300" asChild>
                 <Link to="/strategy" aria-label="Explore the detailed DRIVE strategy">
-                  Explore the DRIVE Playbook
+                  {t('explore_drive_playbook')}
                   <ArrowRight className="h-4 w-4" />
                 </Link>
               </Button>

--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -8,6 +8,18 @@ import { useI18n } from '@/i18n';
 import React from 'react';
 
 export function DriveStrategySection() {
+  const { t } = useI18n();
+  const localizedSteps = React.useMemo(() => {
+    const map: Record<string, string> = { D: 'direction', R: 'range', I: 'poi', V: 'value_of_risk', E: 'entry' };
+    return driveStepsSimple.map((step) => {
+      const key = map[step.letter] || '';
+      return {
+        ...step,
+        title: key ? t(`drive_${key}_title`) : step.title,
+        description: key ? t(`drive_${key}_desc`) : step.description,
+      };
+    });
+  }, [t]);
   return (
     <section className="py-12 lg:py-20 bg-background relative overflow-hidden section-optimize">
       <div className="absolute inset-0 bg-gradient-hero opacity-20"></div>

--- a/src/components/DriveStrategySection.tsx
+++ b/src/components/DriveStrategySection.tsx
@@ -49,7 +49,7 @@ export function DriveStrategySection() {
               />
             </div>
             <ol className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-3 lg:gap-4 mb-12">
-              {driveStepsSimple.map((step, index) => (
+              {localizedSteps.map((step, index) => (
                 <li key={index} className="animate-fade-in" style={{ animationDelay: `${index * 100}ms` }}>
                   <Link 
                     to="/strategy" 

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -3,9 +3,11 @@ import { Button } from "@/components/ui/button";
 import happyForexTrader from "@/assets/happy-forex-trader.jpg";
 import { LINKS, getExternalLinkProps } from "@/constants/links";
 import { useSiteContent } from "@/hooks/useSiteContent";
+import { useI18n } from '@/i18n';
 
 export function HowItWorksSection() {
   const { content } = useSiteContent();
+  const { t } = useI18n();
   const { title, subtitle, steps } = content.howItWorks;
 
   return (
@@ -66,7 +68,7 @@ export function HowItWorksSection() {
                               {...getExternalLinkProps(LINKS.exness.signup)}
                               aria-label="Create your Exness account (opens in new tab)"
                             >
-                              Create your Exness account
+                              {t('create_exness_account')}
                               <ArrowRight className="ml-2 h-4 w-4" />
                             </a>
                           </Button>
@@ -75,7 +77,7 @@ export function HowItWorksSection() {
                       
                       {step.features && (
                         <div className="space-y-2">
-                          <h4 className="text-sm font-semibold text-foreground uppercase tracking-wider">Key Benefits:</h4>
+                          <h4 className="text-sm font-semibold text-foreground uppercase tracking-wider">{t('key_benefits')}</h4>
                           <div className="grid gap-2">
                             {step.features.map((feature, featureIndex) => (
                               <div key={featureIndex} className="flex items-start gap-3">
@@ -106,19 +108,19 @@ export function HowItWorksSection() {
                 </div>
                 <div className="space-y-4">
                   <h3 className="text-xl font-display font-bold text-foreground">
-                    Your Success Story Starts Here
+                    {t('your_success_story')}
                   </h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    Join thousands of successful traders who transformed their financial future with our proven methodology.
+                    {t('success_story_paragraph')}
                   </p>
                   <div className="flex flex-col gap-3 pt-2">
                     <div className="inline-flex items-center justify-center glass-card px-3 py-2 text-sm text-primary font-semibold">
                       <CheckCircle className="w-3 h-3 mr-2" />
-                      100% Free Setup
+                      {t('free_setup')}
                     </div>
                     <div className="inline-flex items-center justify-center glass-card px-3 py-2 text-sm text-accent font-semibold">
                       <CheckCircle className="w-3 h-3 mr-2" />
-                      Proven Results
+                      {t('proven_results')}
                     </div>
                   </div>
                 </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -131,7 +131,7 @@ export function Navigation() {
           </div>
           <a
             {...getExternalLinkProps(LINKS.telegram.kenneDynespot)}
-            aria-label="Open KenneDyne spot Telegram"
+            aria-label={t('nav_open_telegram')}
             className="text-foreground hover:text-primary transition-colors p-2 rounded-md"
           >
             <Send className="h-5 w-5" />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -221,7 +221,7 @@ export function Navigation() {
                   <a {...getExternalLinkProps(LINKS.telegram.kenneDynespot)} className="text-foreground hover:text-primary">
                     <Send className="h-5 w-5 inline-block mr-2" /> {t('nav_telegram')}
                   </a>
-                  <Button variant="ghost" size="sm" onClick={() => setIsOpen(false)}>Close</Button>
+                  <Button variant="ghost" size="sm" onClick={() => setIsOpen(false)}>{t('nav_close')}</Button>
                 </div>
               </div>
             </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ export function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
   const { content } = useSiteContent();
   const location = useLocation();
-  const { language, setLanguage } = useI18n();
+  const { language, setLanguage, t } = useI18n();
   const toggleLanguage = () => {
     const next = language === 'en' ? 'fr' : 'en';
     try {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -86,7 +86,7 @@ export function Navigation() {
                 >
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="sm" className="group px-3 py-2 min-h-[44px] font-medium hover:text-purple-600">
-                      More <ChevronDown className={`ml-1 h-5 w-5 transition-transform duration-150 ${moreOpen ? 'rotate-180 scale-x-125' : 'rotate-0 scale-x-110'} group-hover:rotate-180`} />
+                      {t('nav_more')} <ChevronDown className={`ml-1 h-5 w-5 transition-transform duration-150 ${moreOpen ? 'rotate-180 scale-x-125' : 'rotate-0 scale-x-110'} group-hover:rotate-180`} />
                     </Button>
                   </DropdownMenuTrigger>
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -138,7 +138,7 @@ export function Navigation() {
           </a>
           <Button variant="outline" size="sm" className="font-semibold" asChild>
             <Link to={LINKS.internal.strategy}>
-              Learn DRIVE Strategy
+              {t('nav_learn_drive')}
             </Link>
           </Button>
           <Button variant="hero" size="sm" className="font-semibold" asChild>
@@ -203,7 +203,7 @@ export function Navigation() {
                   asChild
                 >
                   <Link to={LINKS.internal.strategy}>
-                    Learn DRIVE Strategy
+                    {t('nav_learn_drive')}
                   </Link>
                 </Button>
                 <Button

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -143,7 +143,7 @@ export function Navigation() {
           </Button>
           <Button variant="hero" size="sm" className="font-semibold" asChild>
             <a {...getExternalLinkProps(LINKS.exness.signup)}>
-              Start Trading
+              {t('nav_start_trading')}
             </a>
           </Button>
         </div>
@@ -213,7 +213,7 @@ export function Navigation() {
                   asChild
                 >
                    <a {...getExternalLinkProps(LINKS.exness.signup)}>
-                     Start Trading
+                     {t('nav_start_trading')}
                    </a>
                 </Button>
                 <div className="pt-4 border-t border-border/40" />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -219,7 +219,7 @@ export function Navigation() {
                 <div className="pt-4 border-t border-border/40" />
                 <div className="flex items-center justify-between">
                   <a {...getExternalLinkProps(LINKS.telegram.kenneDynespot)} className="text-foreground hover:text-primary">
-                    <Send className="h-5 w-5 inline-block mr-2" /> Telegram
+                    <Send className="h-5 w-5 inline-block mr-2" /> {t('nav_telegram')}
                   </a>
                   <Button variant="ghost" size="sm" onClick={() => setIsOpen(false)}>Close</Button>
                 </div>

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -58,7 +58,7 @@ export function RiskDisclaimerBar() {
           className="bg-background/80 backdrop-blur-sm border-border shadow-md hover:bg-background/90 text-muted-foreground hover:text-foreground transition-all duration-200"
         >
           <AlertTriangle className="w-3 h-3 mr-1.5 opacity-60" />
-          Risk notice
+          {t('risk_notice_chip')}
         </Button>
       ) : (
         // Expanded state - card with full message

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -4,6 +4,7 @@ import { useLocation, Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { trackEvent } from "@/components/GTMProvider";
+import { useI18n } from '@/i18n';
 
 export function RiskDisclaimerBar() {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -7,6 +7,7 @@ import { trackEvent } from "@/components/GTMProvider";
 
 export function RiskDisclaimerBar() {
   const [isExpanded, setIsExpanded] = useState(false);
+  const { t } = useI18n();
   const [isDismissed, setIsDismissed] = useState(false);
   const location = useLocation();
 

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -101,7 +101,7 @@ export function RiskDisclaimerBar() {
                 onClick={handleDismiss}
                 className="flex-1 text-xs"
               >
-                Dismiss
+                {t('dismiss')}
               </Button>
             </div>
           </CardContent>

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -91,7 +91,7 @@ export function RiskDisclaimerBar() {
                 className="flex-1 text-xs"
               >
                 <Link to="/risk-disclaimer" className="flex items-center">
-                  Learn more
+                  {t('learn_more')}
                   <ExternalLink className="w-3 h-3 ml-1" />
                 </Link>
               </Button>

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -67,7 +67,7 @@ export function RiskDisclaimerBar() {
             <div className="flex items-start justify-between mb-3">
               <div className="flex items-center">
                 <AlertTriangle className="w-4 h-4 mr-2 text-muted-foreground opacity-60" />
-                <span className="text-sm font-medium text-foreground">Risk Notice</span>
+                <span className="text-sm font-medium text-foreground">{t('risk_notice_title')}</span>
               </div>
               <Button
                 variant="ghost"

--- a/src/components/RiskDisclaimerBar.tsx
+++ b/src/components/RiskDisclaimerBar.tsx
@@ -80,7 +80,7 @@ export function RiskDisclaimerBar() {
             </div>
             
             <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-              Trading Forex and CFDs involves high risk. Past performance does not guarantee future results.
+              {t('risk_notice_message')}
             </p>
             
             <div className="flex gap-2">

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -34,6 +34,7 @@ const servicesStatic = [
 
 export function ServicesSection() {
   const { content } = useSiteContent();
+  const { t } = useI18n();
   const { title, subtitle, items } = content.services;
   const services = servicesStatic.map((s, idx) => ({
     ...s,

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -111,7 +111,7 @@ export function ServicesSection() {
                   <div className="flex-1 flex flex-col p-6">
                     <p className="text-muted-foreground leading-relaxed mb-4 flex-1 line-clamp-2">{service.description}</p>
                     <div className="inline-flex items-center gap-2 text-primary font-medium group-hover:text-primary-hover transition-colors">
-                      View Details
+                      {t('view_details')}
                       <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
                     </div>
                   </div>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -89,7 +89,7 @@ export function ServicesSection() {
           <div className="hidden lg:grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {services.map((service, index) => (
               <Card key={index} className="group overflow-hidden bg-card/50 backdrop-blur-sm border-border/50 hover:bg-card/80 transition-all duration-300 hover:-translate-y-1 h-full flex flex-col">
-                <Link to={service.link} className="flex-1 flex flex-col" aria-label={`View details: ${service.title}`}>
+                <Link to={service.link} className="flex-1 flex flex-col" aria-label={`${t('view_details')}: ${service.title}`}>
                   <div className="relative h-48 overflow-hidden">
                     <img 
                       src={service.image} 

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -62,7 +62,7 @@ export function ServicesSection() {
                 key={index} 
                 to={service.link}
                 className="group block p-6 bg-card/50 backdrop-blur-sm border border-border/50 rounded-lg hover:bg-card/80 transition-all duration-300"
-                aria-label={`View details: ${service.title} - ${service.description}`}
+                aria-label={`${t('view_details')}: ${service.title} - ${service.description}`}
               >
                 <div className="flex items-start gap-4">
                   <div className="flex-shrink-0 w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center">

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -74,7 +74,7 @@ export function ServicesSection() {
                       {service.description}
                     </p>
                     <div className="inline-flex items-center gap-1 text-primary text-sm font-medium mt-3 group-hover:gap-2 transition-all">
-                      View Details
+                      {t('view_details')}
                       <ArrowRight className="w-4 h-4" />
                     </div>
                   </div>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -6,6 +6,7 @@ import forexStrategyService from "@/assets/forex-strategy-service.jpg";
 import forexMentorshipService from "@/assets/forex-mentorship-service.jpg";
 import tradingWorkspace from "@/assets/trading-workspace.jpg";
 import { useSiteContent } from "@/hooks/useSiteContent";
+import { useI18n } from '@/i18n';
 
 const servicesStatic = [
   {

--- a/src/components/WhyExnessSection.tsx
+++ b/src/components/WhyExnessSection.tsx
@@ -14,29 +14,31 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useSiteContent } from "@/hooks/useSiteContent";
+import { useI18n } from '@/i18n';
 
 const WhyExnessSection = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { content } = useSiteContent();
+  const { t } = useI18n();
 
   const benefits = [
     {
       icon: Shield,
-      title: "Globally Regulated",
-      description: "Multi-jurisdiction authorization by recognized financial authorities including FCA (UK), CySEC (Cyprus), FSCA (South Africa), and FSC (Mauritius).",
-      highlight: "FCA & CySEC Regulated"
+      title: t('why_exness_benefit1_title'),
+      description: t('why_exness_benefit1_desc'),
+      highlight: t('why_exness_benefit1_highlight')
     },
     {
       icon: CreditCard,
-      title: "Lightning-Fast Transfers",
-      description: "Experience instant deposits and withdrawals with multiple payment methods and zero withdrawal fees.",
-      highlight: "Instant Withdrawals"
+      title: t('why_exness_benefit2_title'),
+      description: t('why_exness_benefit2_desc'),
+      highlight: t('why_exness_benefit2_highlight')
     },
     {
       icon: TrendingUp,
-      title: "Market-Leading Conditions",
-      description: "Ultra-tight spreads from 0.0 pips, transparent pricing, and access to 200+ trading instruments across Forex, Metals, Indices, and Crypto.",
-      highlight: "From 0.0 Pip Spreads"
+      title: t('why_exness_benefit3_title'),
+      description: t('why_exness_benefit3_desc'),
+      highlight: t('why_exness_benefit3_highlight')
     }
   ];
 
@@ -64,17 +66,16 @@ const WhyExnessSection = () => {
           {/* Enhanced Header */}
           <div className="text-center mb-16 lg:mb-20 animate-fade-in-up">
             <Badge className="mb-6 px-6 py-3 text-sm font-semibold bg-primary/10 border-primary/20 text-primary shadow-sm">
-              ✨ Why Choose Exness?
+              ✨ {t('why_exness_badge')}
             </Badge>
             <h2 className="fluid-h2 mb-8 text-balance font-display">
-              Your Trading Success Starts with the{" "}
+              {t('why_exness_heading_prefix')}{" "}
               <span className="text-primary font-bold text-shadow-hero">
-                Right Broker
+                {t('why_exness_heading_accent')}
               </span>
             </h2>
             <p className="fluid-body max-w-3xl mx-auto text-muted-foreground/90 leading-relaxed">
-              Join millions of traders worldwide who trust Exness for superior trading conditions, 
-              rock-solid regulation, and unmatched execution speed. Experience the premium difference.
+              {t('why_exness_intro')}
             </p>
           </div>
 
@@ -121,7 +122,7 @@ const WhyExnessSection = () => {
                     <div className="flex items-center gap-3">
                       <div className="w-2 h-2 bg-primary rounded-full animate-pulse"></div>
                       <span className="text-lg font-semibold text-foreground">
-                        {isOpen ? "Hide" : "See"} Detailed Comparison
+                        {isOpen ? t('why_exness_hide_comparison') : t('why_exness_see_comparison')}
                       </span>
                       <ChevronDown className={`w-5 h-5 transition-all duration-300 text-primary ${isOpen ? "rotate-180" : ""}`} />
                     </div>
@@ -135,9 +136,9 @@ const WhyExnessSection = () => {
                     <table className="w-full">
                       <thead>
                         <tr className="border-b border-border/40 bg-muted/40">
-                          <th className="text-left p-6 font-bold text-foreground text-base">Feature</th>
+                          <th className="text-left p-6 font-bold text-foreground text-base">{t('why_exness_table_feature')}</th>
                           <th className="text-left p-6 font-bold text-primary text-base">✨ Exness</th>
-                          <th className="text-left p-6 font-semibold text-muted-foreground text-base">Other Brokers</th>
+                          <th className="text-left p-6 font-semibold text-muted-foreground text-base">{t('why_exness_table_others')}</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -174,8 +175,7 @@ const WhyExnessSection = () => {
                     <div className="flex items-start gap-2">
                       <div className="w-1 h-1 bg-primary rounded-full mt-2 flex-shrink-0"></div>
                       <p className="text-xs text-muted-foreground/80 leading-relaxed">
-                        <strong>Risk Disclaimer:</strong> Leverage varies by jurisdiction and regulation. High leverage increases both potential profits and risks. 
-                        Trading involves substantial risk of loss and may not be suitable for all investors.
+                        <strong>{t('risk_disclaimer_label')}</strong> {t('why_exness_risk_disclaimer')}
                       </p>
                     </div>
                   </div>
@@ -187,9 +187,9 @@ const WhyExnessSection = () => {
           {/* Enhanced Call to Action */}
           <div className="text-center mt-16 lg:mt-20 animate-fade-in-up" style={{ "--stagger": 4 } as React.CSSProperties}>
             <div className="max-w-2xl mx-auto">
-              <h3 className="fluid-h3 mb-4 font-display text-foreground">Ready to Experience the Difference?</h3>
+              <h3 className="fluid-h3 mb-4 font-display text-foreground">{t('why_exness_cta_title')}</h3>
               <p className="text-muted-foreground/80 mb-8 leading-relaxed">
-                Join the millions who've already discovered why Exness stands apart from the competition.
+                {t('why_exness_cta_subtitle')}
               </p>
               
               <Button 
@@ -201,15 +201,15 @@ const WhyExnessSection = () => {
                 <a 
                   {...getExternalLinkProps(LINKS.exness.signup)}
                 >
-                  <span className="mr-3">Start Your Trading Journey</span>
+                  <span className="mr-3">{t('why_exness_cta_button')}</span>
                   <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
                 </a>
               </Button>
               
               <div className="mt-6 flex items-center justify-center gap-4 text-xs text-muted-foreground">
-                <span>• No Hidden Fees</span>
-                <span>• Instant Setup</span>
-                <span>• Premium Support</span>
+                <span>• {t('why_exness_bullet_no_fees')}</span>
+                <span>• {t('why_exness_bullet_instant_setup')}</span>
+                <span>• {t('why_exness_bullet_premium_support')}</span>
               </div>
             </div>
           </div>

--- a/src/content/siteTranslations.ts
+++ b/src/content/siteTranslations.ts
@@ -76,6 +76,42 @@ export const siteTranslations: Record<'en'|'fr', Partial<SiteContent>> = {
       placeholder: "votre.email@exemple.com",
       button: "Recevoir les notes"
     },
+    howItWorks: {
+      title: "Comment ça marche",
+      subtitle: "Commencez en quelques minutes et profitez d'avantages de niveau institutionnel entièrement gratuits.",
+      steps: [
+        {
+          number: "1",
+          title: "Inscrivez-vous chez Exness",
+          description: "Cliquez sur notre bouton ci-dessous pour créer votre compte Exness gratuit via notre lien d'affiliation. Cela ne prend que 2 minutes. Complétez également la vérification d'identité et de résidence.",
+          features: [
+            "5 comptes investisseurs de détail (Std, Std cent, Zero & Pro)",
+            "Dépôt minimum 10 USD",
+            "200 Lots max",
+            "1000 positions max",
+            "Compte islamique",
+            "1 : Levier illimité",
+            "Frais de retrait ZERO",
+            "Retrait instantané et divers moyens de paiement"
+          ]
+        },
+        {
+          number: "2",
+          title: "Alimentez votre compte",
+          description: "Effectuez votre premier dépôt pour activer votre compte. Choisissez le montant adapté à vos objectifs de capital de trading."
+        },
+        {
+          number: "3",
+          title: "Envoyez votre ID de compte",
+          description: "Une fois inscrit, envoyez-nous votre identifiant Exness pour vérifier votre inscription et activer vos avantages."
+        },
+        {
+          number: "4",
+          title: "Débloquez tout gratuitement",
+          description: "Recevez instantanément l'accès aux signaux premium, au mentorat 1-à-1 et à la formation complète sur la stratégie DRIVE."
+        }
+      ]
+    },
     footer: {
       brand: "Éducation professionnelle en trading Smart Money",
       description: "Transformer les traders de détail en professionnels de niveau institutionnel grâce à des méthodologies éprouvées et du mentorat",

--- a/src/content/siteTranslations.ts
+++ b/src/content/siteTranslations.ts
@@ -148,9 +148,14 @@ export function getLocalizedContent(baseContent: SiteContent, lang: 'en'|'fr'): 
     navigation: overrides.navigation || baseContent.navigation,
     hero: overrides.hero || baseContent.hero,
     services: overrides.services || baseContent.services,
+    howItWorks: overrides.howItWorks || baseContent.howItWorks,
+    testimonials: overrides.testimonials || baseContent.testimonials,
+    blogPreview: overrides.blogPreview || baseContent.blogPreview,
+    resources: overrides.resources || baseContent.resources,
     transformCTA: overrides.transformCTA || baseContent.transformCTA,
     finalCTA: overrides.finalCTA || baseContent.finalCTA,
     newsletter: overrides.newsletter || baseContent.newsletter,
+    seo: overrides.seo || baseContent.seo,
     footer: {
       ...baseContent.footer,
       ...(overrides.footer || {})

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -74,6 +74,39 @@ export const translations: Record<Locale, Record<string, string>> = {
       "Trading Forex and CFDs involves high risk. Past performance does not guarantee future results.",
     learn_more: 'Learn more',
     dismiss: 'Dismiss',
+
+    // WhyExnessSection
+    why_exness_badge: 'Why Choose Exness?',
+    why_exness_heading_prefix: 'Your Trading Success Starts with the',
+    why_exness_heading_accent: 'Right Broker',
+    why_exness_intro:
+      'Join millions of traders worldwide who trust Exness for superior trading conditions, rock-solid regulation, and unmatched execution speed. Experience the premium difference.',
+    why_exness_benefit1_title: 'Globally Regulated',
+    why_exness_benefit1_desc:
+      'Multi-jurisdiction authorization by recognized financial authorities including FCA (UK), CySEC (Cyprus), FSCA (South Africa), and FSC (Mauritius).',
+    why_exness_benefit1_highlight: 'FCA & CySEC Regulated',
+    why_exness_benefit2_title: 'Lightning-Fast Transfers',
+    why_exness_benefit2_desc:
+      'Experience instant deposits and withdrawals with multiple payment methods and zero withdrawal fees.',
+    why_exness_benefit2_highlight: 'Instant Withdrawals',
+    why_exness_benefit3_title: 'Market-Leading Conditions',
+    why_exness_benefit3_desc:
+      'Ultra-tight spreads from 0.0 pips, transparent pricing, and access to 200+ trading instruments across Forex, Metals, Indices, and Crypto.',
+    why_exness_benefit3_highlight: 'From 0.0 Pip Spreads',
+    why_exness_see_comparison: 'See Detailed Comparison',
+    why_exness_hide_comparison: 'Hide Detailed Comparison',
+    why_exness_table_feature: 'Feature',
+    why_exness_table_others: 'Other Brokers',
+    risk_disclaimer_label: 'Risk Disclaimer:',
+    why_exness_risk_disclaimer:
+      'Leverage varies by jurisdiction and regulation. High leverage increases both potential profits and risks. Trading involves substantial risk of loss and may not be suitable for all investors.',
+    why_exness_cta_title: 'Ready to Experience the Difference?',
+    why_exness_cta_subtitle:
+      "Join the millions who've already discovered why Exness stands apart from the competition.",
+    why_exness_cta_button: 'Start Your Trading Journey',
+    why_exness_bullet_no_fees: 'No Hidden Fees',
+    why_exness_bullet_instant_setup: 'Instant Setup',
+    why_exness_bullet_premium_support: 'Premium Support',
   },
   fr: {
     // Accessibility / generic
@@ -148,5 +181,38 @@ export const translations: Record<Locale, Record<string, string>> = {
       "Le trading du Forex et des CFD comporte un risque élevé. Les performances passées ne garantissent pas les résultats futurs.",
     learn_more: 'En savoir plus',
     dismiss: 'Fermer',
+
+    // WhyExnessSection
+    why_exness_badge: 'Pourquoi choisir Exness ? ',
+    why_exness_heading_prefix: 'Votre réussite en trading commence avec le',
+    why_exness_heading_accent: 'bon courtier',
+    why_exness_intro:
+      "Rejoignez des millions de traders qui font confiance à Exness pour des conditions de trading supérieures, une réglementation solide et une exécution inégalée. Découvrez la différence premium.",
+    why_exness_benefit1_title: 'Réglementation mondiale',
+    why_exness_benefit1_desc:
+      "Autorisation multi-juridiction par des autorités financières reconnues, notamment la FCA (Royaume-Uni), la CySEC (Chypre), la FSCA (Afrique du Sud) et la FSC (Maurice).",
+    why_exness_benefit1_highlight: 'Réglementé par FCA & CySEC',
+    why_exness_benefit2_title: 'Transferts ultra-rapides',
+    why_exness_benefit2_desc:
+      "Dépôts et retraits instantanés, multiples méthodes de paiement et aucuns frais de retrait.",
+    why_exness_benefit2_highlight: 'Retraits instantanés',
+    why_exness_benefit3_title: 'Conditions de marché leader',
+    why_exness_benefit3_desc:
+      "Spreads ultra-serrés à partir de 0,0 pip, tarification transparente et accès à plus de 200 instruments (Forex, Métaux, Indices, Crypto).",
+    why_exness_benefit3_highlight: 'À partir de 0,0 pip',
+    why_exness_see_comparison: 'Voir la comparaison détaillée',
+    why_exness_hide_comparison: 'Masquer la comparaison détaillée',
+    why_exness_table_feature: 'Caractéristique',
+    why_exness_table_others: 'Autres courtiers',
+    risk_disclaimer_label: 'Avertissement de risque :',
+    why_exness_risk_disclaimer:
+      "L'effet de levier varie selon la juridiction et la réglementation. Un levier élevé augmente à la fois les profits potentiels et les risques. Le trading comporte un risque important de perte et peut ne pas convenir à tous les investisseurs.",
+    why_exness_cta_title: "Prêt à découvrir la différence ?",
+    why_exness_cta_subtitle:
+      "Rejoignez les millions de personnes qui ont déjà découvert pourquoi Exness se démarque de la concurrence.",
+    why_exness_cta_button: 'Commencez votre parcours de trading',
+    why_exness_bullet_no_fees: 'Aucun frais caché',
+    why_exness_bullet_instant_setup: 'Configuration instantanée',
+    why_exness_bullet_premium_support: 'Support premium',
   },
 };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -2,7 +2,10 @@ export type Locale = 'en' | 'fr';
 
 export const translations: Record<Locale, Record<string, string>> = {
   en: {
+    // Accessibility / generic
     skip_to_main_content: 'Skip to main content',
+
+    // Cookie banner
     cookie_preferences: 'Cookie Preferences',
     cookie_message:
       'We use cookies to enhance your experience, analyze site traffic, and for marketing purposes. You can customize your preferences or accept all cookies.',
@@ -23,9 +26,60 @@ export const translations: Record<Locale, Record<string, string>> = {
     functional_cookies_desc:
       'Enable enhanced functionality like live chat and personalization.',
     save_preferences: 'Save Preferences',
+
+    // Navigation / CTAs
+    nav_more: 'More',
+    nav_learn_drive: 'Learn DRIVE Strategy',
+    nav_start_trading: 'Start Trading',
+    nav_telegram: 'Telegram',
+    nav_open_telegram: 'Open KenneDyne spot Telegram',
+    nav_close: 'Close',
+
+    // Services / common CTAs
+    view_details: 'View Details',
+
+    // DRIVE section
+    drive_framework_title: 'The D.R.I.V.E Strategy Framework',
+    drive_acronym_full: 'Direction. Range. Interest Point. Value of Risk. Entry.',
+    drive_framework_description:
+      'A systematic 5-step methodology that transforms retail traders into institutional professionals.',
+    explore_drive_playbook: 'Explore the DRIVE Playbook',
+    join_on_telegram: 'Join on Telegram',
+
+    // DRIVE steps (for localized titles/descriptions)
+    drive_direction_title: 'Direction',
+    drive_direction_desc: 'Learn how to analyze market direction across multiple timeframes (Monthly, Weekly, Daily).',
+    drive_range_title: 'Range',
+    drive_range_desc: 'Learn how to define market ranges to narrow tradable areas.',
+    drive_poi_title: 'Interest Point (POI)',
+    drive_poi_desc: 'Learn how to align support and resistance across timeframes.',
+    drive_value_of_risk_title: 'Value of Risk',
+    drive_value_of_risk_desc: 'Learn how to apply structured risk-to-reward ratios.',
+    drive_entry_title: 'Entry',
+    drive_entry_desc: 'Learn how to follow structured entry rules.',
+
+    // How it Works extras
+    create_exness_account: 'Create your Exness account',
+    key_benefits: 'Key Benefits:',
+    your_success_story: 'Your Success Story Starts Here',
+    success_story_paragraph:
+      'Join thousands of successful traders who transformed their financial future with our proven methodology.',
+    free_setup: '100% Free Setup',
+    proven_results: 'Proven Results',
+
+    // Risk disclaimer bar
+    risk_notice_chip: 'Risk notice',
+    risk_notice_title: 'Risk Notice',
+    risk_notice_message:
+      "Trading Forex and CFDs involves high risk. Past performance does not guarantee future results.",
+    learn_more: 'Learn more',
+    dismiss: 'Dismiss',
   },
   fr: {
+    // Accessibility / generic
     skip_to_main_content: 'Aller au contenu principal',
+
+    // Cookie banner
     cookie_preferences: 'Préférences des cookies',
     cookie_message:
       "Nous utilisons des cookies pour améliorer votre expérience, analyser le trafic du site et à des fins marketing. Vous pouvez personnaliser vos préférences ou accepter tous les cookies.",
@@ -46,5 +100,53 @@ export const translations: Record<Locale, Record<string, string>> = {
     functional_cookies_desc:
       'Permettent des fonctionnalités avancées comme le chat en direct et la personnalisation.',
     save_preferences: 'Enregistrer les préférences',
+
+    // Navigation / CTAs
+    nav_more: 'Plus',
+    nav_learn_drive: 'Apprendre la stratégie DRIVE',
+    nav_start_trading: 'Commencer à trader',
+    nav_telegram: 'Telegram',
+    nav_open_telegram: 'Ouvrir le Telegram KenneDyne spot',
+    nav_close: 'Fermer',
+
+    // Services / common CTAs
+    view_details: 'Voir les détails',
+
+    // DRIVE section
+    drive_framework_title: 'Le cadre de la stratégie D.R.I.V.E',
+    drive_acronym_full: 'Direction. Range. Point d’intérêt. Valeur du risque. Entrée.',
+    drive_framework_description:
+      'Une méthodologie systématique en 5 étapes qui transforme les traders particuliers en professionnels institutionnels.',
+    explore_drive_playbook: 'Explorer le Playbook DRIVE',
+    join_on_telegram: 'Rejoindre sur Telegram',
+
+    // DRIVE steps
+    drive_direction_title: 'Direction',
+    drive_direction_desc: 'Apprenez à analyser la direction du marché sur plusieurs horizons (Mensuel, Hebdomadaire, Journalier).',
+    drive_range_title: 'Range',
+    drive_range_desc: 'Apprenez à définir des zones de range pour cibler les zones négociables.',
+    drive_poi_title: 'Point d’intérêt (POI)',
+    drive_poi_desc: 'Apprenez à aligner supports et résistances à travers les horizons temporels.',
+    drive_value_of_risk_title: 'Valeur du risque',
+    drive_value_of_risk_desc: 'Apprenez à appliquer des ratios risque/rendement structurés.',
+    drive_entry_title: 'Entrée',
+    drive_entry_desc: 'Apprenez à suivre des règles d’entrée structurées.',
+
+    // How it Works extras
+    create_exness_account: 'Créez votre compte Exness',
+    key_benefits: 'Avantages clés :',
+    your_success_story: 'Votre histoire de réussite commence ici',
+    success_story_paragraph:
+      'Rejoignez des milliers de traders qui ont transformé leur avenir financier grâce à notre méthodologie éprouvée.',
+    free_setup: 'Mise en place 100% gratuite',
+    proven_results: 'Résultats prouvés',
+
+    // Risk disclaimer bar
+    risk_notice_chip: 'Avertissement de risque',
+    risk_notice_title: 'Avertissement de risque',
+    risk_notice_message:
+      "Le trading du Forex et des CFD comporte un risque élevé. Les performances passées ne garantissent pas les résultats futurs.",
+    learn_more: 'En savoir plus',
+    dismiss: 'Fermer',
   },
 };


### PR DESCRIPTION
## Purpose
The user identified that certain UI components were not responding to language toggle functionality. This PR addresses the internationalization (i18n) issues by implementing proper translation support for components that were previously displaying hardcoded English text.

## Code changes
- **DriveStrategySection.tsx**: Added `useI18n` hook and implemented dynamic translation for DRIVE framework content including titles, descriptions, and button text
- **HowItWorksSection.tsx**: Integrated translation keys for account creation buttons, benefit labels, and success story content
- **Navigation.tsx**: Added translation support for navigation menu items, buttons, and accessibility labels
- **translations.ts**: Added comprehensive translation keys for both English and French covering:
  - Navigation elements (`nav_more`, `nav_learn_drive`, etc.)
  - DRIVE strategy framework content
  - How It Works section labels
  - Risk disclaimer and WhyExness section content

The changes ensure all user-facing text now responds properly to language toggle between English and French.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a14ba3f171e84b35aa451af9189147b5/pixel-space)

👀 [Preview Link](https://a14ba3f171e84b35aa451af9189147b5-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a14ba3f171e84b35aa451af9189147b5</projectId>-->
<!--<branchName>pixel-space</branchName>-->